### PR TITLE
Add some URL cleanups to the API-Mate tool

### DIFF
--- a/lib/api_mate.js
+++ b/lib/api_mate.js
@@ -53,9 +53,10 @@
     var api, customCalls, line, lines, paramName, paramValue, params, separator, server, urls, _i, _j, _len, _len1;
     server = {};
     server.url = $("#input-custom-server-url").val();
-    server.name = server.url;
     server.salt = $("#input-custom-server-salt").val();
     server.mobileSalt = $("#input-custom-server-mobile-salt").val();
+    server.url = server.url.replace(/(\/api)?\/?$/, '/api');
+    server.name = server.url;
     params = {};
     if (isFilled("#input-name")) {
       params.name = $("#input-name").val();

--- a/src/api_mate.coffee
+++ b/src/api_mate.coffee
@@ -57,9 +57,13 @@ addUrlsToPage = (urls) ->
 generateUrls = () ->
   server = {}
   server.url = $("#input-custom-server-url").val()
-  server.name = server.url
   server.salt = $("#input-custom-server-salt").val()
   server.mobileSalt = $("#input-custom-server-mobile-salt").val()
+
+  # Do some cleanups on the server URL to that pasted URLs in various formats work better
+  # Remove trailing /, and add /api on the end if missing.
+  server.url = server.url.replace(/(\/api)?\/?$/, '/api')
+  server.name = server.url
 
   # set ALL the parameters
   params = {}


### PR DESCRIPTION
This means you can just copy/paste the URL from various sources, and it's less likely to break.

In particular, this fixes:
- URLs that contain a trailing slash after /api (it will be removed)
- URLs that are missing the /api on the end (it will be added)
