### PR TITLE
Remove remaining tooltips when we update URLs

### DIFF
--- a/src/js/api_mate.coffee
+++ b/src/js/api_mate.coffee
@@ -139,6 +139,7 @@ window.ApiMate = class ApiMate
       title: new Date().toTimeString()
       urls: urls
     html = Mustache.to_html(@templates['results'], opts)
+    $('.results-tooltip').remove()
     $(placeholder).html(html)
     @expandLinks($("[data-api-mate-expand]").hasClass("active"))
 

--- a/src/js/application.coffee
+++ b/src/js/application.coffee
@@ -6,4 +6,5 @@ window.Application = class Application
     defaultOptions =
       container: 'body'
       placement: 'top'
+      template: '<div class="tooltip results-tooltip" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>'
     $('.tooltipped').tooltip(defaultOptions)


### PR DESCRIPTION
The tooltip freezes everytime we update URLs during a visualization (for example, 'tab-ing' beetwen inputs while mouse is over a tooltip). This happens because tooltip's mark is lost when we update URLs, once we rewrite all placeholder's inner html.  Since tooltip is appended to the body tag (and not as a child of placeholder), it stays in the page when we replace the code with new URLs.