### PR TITLE
Add support for new checksum options

### DIFF
--- a/src/js/api_mate.coffee
+++ b/src/js/api_mate.coffee
@@ -164,10 +164,16 @@ window.ApiMate = class ApiMate
     server.name = server.url
 
     opts = {}
-    if $("[data-api-mate-sha='sha256']").hasClass("active")
-      opts.shaType = 'sha256'
-    else
-      opts.shaType = 'sha1'
+    shaLevels = [
+      'sha1',
+      'sha256',
+      'sha384',
+      'sha512',
+    ]
+    # Find the active SHA level, could have only one active so we can break out of the loop 
+    for level in shaLevels 
+      if $("[data-api-mate-sha='#{level}']").hasClass("active")
+        opts.shaType = level
 
     new BigBlueButtonApi(server.url, server.salt, @debug, opts)
 

--- a/src/views/_menu.jade
+++ b/src/views/_menu.jade
@@ -14,12 +14,19 @@
         i.glyphicon.glyphicon-check
         | Debug messages
     div.btn-group(data-toggle="buttons")
-      .btn.btn-info.btn-xs.active(data-api-mate-sha='sha1')
+      .btn.btn-info.btn-xs(data-api-mate-sha='sha1')
         input(type="radio", name="sha1")
         | SHA1
-      .btn.btn-info.btn-xs(data-api-mate-sha='sha256')
+      .btn.btn-info.btn-xs.active(data-api-mate-sha='sha256')
         input(type="radio", name="sha256")
         | SHA256
+      .btn.btn-info.btn-xs(data-api-mate-sha='sha384')
+        input(type="radio", name="sha384")
+        | SHA384
+      .btn.btn-info.btn-xs(data-api-mate-sha='sha512')
+        input(type="radio", name="sha512")
+        | SHA512
+
 
 #menu-server
   .section-title Server URL and shared secret


### PR DESCRIPTION
Add support for the new checksum types (sha384 and sha512), added in the PR https://github.com/bigbluebutton/bigbluebutton/pull/15684

NOTE: This PR should be hold until the release of the new bigbluebutton-api-js version containing the PR https://github.com/mconf/bigbluebutton-api-js/pull/10